### PR TITLE
Breaking : Manage public authorization on new user

### DIFF
--- a/lib/directus_api_manager.dart
+++ b/lib/directus_api_manager.dart
@@ -6,3 +6,4 @@ export 'src/sort_property.dart';
 export 'src/model/directus_user.dart';
 export 'src/model/directus_file.dart';
 export 'src/model/directus_login_result.dart';
+export 'src/model/directus_create_user_result.dart';

--- a/lib/directus_api_manager.dart
+++ b/lib/directus_api_manager.dart
@@ -6,4 +6,6 @@ export 'src/sort_property.dart';
 export 'src/model/directus_user.dart';
 export 'src/model/directus_file.dart';
 export 'src/model/directus_login_result.dart';
-export 'src/model/directus_create_user_result.dart';
+export 'src/model/directus_item.dart';
+export 'src/model/directus_write_item_result.dart';
+export 'src/model/directus_write_multi_result.dart';

--- a/lib/src/directus_api.dart
+++ b/lib/src/directus_api.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:developer';
 
 import 'package:directus_api_manager/src/filter.dart';
+import 'package:directus_api_manager/src/model/directus_create_user_result.dart';
 import 'package:directus_api_manager/src/model/directus_file.dart';
 import 'package:directus_api_manager/src/model/directus_login_result.dart';
 import 'package:directus_api_manager/src/model/directus_user.dart';
@@ -20,7 +21,7 @@ abstract class IDirectusAPI {
   BaseRequest authenticateRequest(BaseRequest request);
   BaseRequest prepareGetCurrentUserRequest({String fields = "*"});
   DirectusUser parseUserResponse(Response response);
-  bool parseCreateUserResponse(Response response);
+  DirectusCreateUserResult parseCreateUserResponse(Response response);
 
   BaseRequest prepareUpdateUserRequest(DirectusUser updatedUser);
   BaseRequest prepareGetUserListRequest({Filter? filter, required int limit});
@@ -389,8 +390,16 @@ class DirectusAPI implements IDirectusAPI {
   }
 
   @override
-  bool parseCreateUserResponse(Response response) {
-    return response.statusCode == 200 || response.statusCode == 204;
+  DirectusCreateUserResult parseCreateUserResponse(Response response) {
+    if (response.statusCode == 200) {
+      final DirectusUser userCreated = parseUserResponse(response);
+      return DirectusCreateUserResult(
+          isSuccess: true, userCreated: userCreated);
+    } else if (response.statusCode == 204) {
+      return DirectusCreateUserResult(isSuccess: true);
+    } else {
+      return DirectusCreateUserResult(isSuccess: false);
+    }
   }
 
   @override

--- a/lib/src/directus_api.dart
+++ b/lib/src/directus_api.dart
@@ -19,6 +19,7 @@ abstract class IDirectusAPI {
       {String fields = "*"});
   BaseRequest prepareGetCurrentUserRequest({String fields = "*"});
   DirectusUser parseUserResponse(Response response);
+  bool parseCreateUserResponse(Response response);
 
   BaseRequest prepareUpdateUserRequest(DirectusUser updatedUser);
   BaseRequest prepareGetUserListRequest({Filter? filter, required int limit});
@@ -383,6 +384,11 @@ class DirectusAPI implements IDirectusAPI {
     } else {
       throw "Invalid user response format";
     }
+  }
+
+  @override
+  bool parseCreateUserResponse(Response response) {
+    return response.statusCode == 200 || response.statusCode == 204;
   }
 
   @override

--- a/lib/src/directus_api_manager_base.dart
+++ b/lib/src/directus_api_manager_base.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:directus_api_manager/directus_api_manager.dart';
 import 'package:directus_api_manager/src/directus_api.dart';
-import 'package:directus_api_manager/src/model/directus_create_user_result.dart';
 import 'package:http/http.dart';
 
 class DirectusApiManager {
@@ -173,7 +172,7 @@ class DirectusApiManager {
         parseResponse: _api.parseGenericBoolResponse);
   }
 
-  Future<DirectusCreateUserResult> createNewDirectusUser(
+  Future<DirectusWriteItemResult> createNewDirectusUser(
       {required String email,
       required String password,
       String? firstname,
@@ -233,49 +232,42 @@ class DirectusApiManager {
             jsonConverter(_api.parseGetSpecificItemResponse(response)));
   }
 
-  Future<Type> createNewItem<Type>(
+  Future<DirectusWriteItemResult> createNewItem(
       {required String typeName,
       required Map<String, dynamic> objectData,
-      required Type Function(dynamic) jsonConverter}) {
+      required DirectusItem object}) {
     return _sendRequest(
         prepareRequest: () =>
             _api.prepareCreateNewItemRequest(typeName, objectData),
         parseResponse: (response) =>
-            jsonConverter(_api.parseCreateNewItemResponse(response)));
+            _api.parseCreateNewItemResponse(response, object));
   }
 
-  Future<List<Type>> createMultipleItems<Type>(
+  Future<DirectusMultiWriteItemResult> createMultipleItems<Type>(
       {required String typeName,
       String fields = "*",
       required Iterable<Map<String, dynamic>> objectListData,
-      required Type Function(dynamic) jsonConverter}) {
+      required DirectusItem object}) {
     return _sendRequest(
         prepareRequest: () => _api.prepareCreateNewItemRequest(
             typeName, objectListData,
             fields: fields),
         parseResponse: (response) {
-          final List<Type> createdItemsList = [];
-          final listJson = _api.parseCreateNewItemResponse(response);
-          if (listJson is List) {
-            for (final itemJson in listJson) {
-              createdItemsList.add(jsonConverter(itemJson));
-            }
-          }
-          return createdItemsList;
+          return _api.parseCreateMultiItemResponse(response, object);
         });
   }
 
-  Future<Type> updateItem<Type>(
+  Future<DirectusWriteItemResult> updateItem<Type>(
       {required String typeName,
       required String objectId,
       required Map<String, dynamic> objectData,
-      required Type Function(dynamic) jsonConverter,
+      required DirectusItem object,
       String fields = "*"}) {
     return _sendRequest(
         prepareRequest: () => _api.prepareUpdateItemRequest(
             typeName, objectId, objectData, fields: fields),
         parseResponse: (response) =>
-            jsonConverter(_api.parseUpdateItemResponse(response)));
+            _api.parseUpdateItemResponse(response, object));
   }
 
   Future<bool> deleteItem(

--- a/lib/src/directus_api_manager_base.dart
+++ b/lib/src/directus_api_manager_base.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:directus_api_manager/directus_api_manager.dart';
 import 'package:directus_api_manager/src/directus_api.dart';
+import 'package:directus_api_manager/src/model/directus_create_user_result.dart';
 import 'package:http/http.dart';
 
 class DirectusApiManager {
@@ -172,7 +173,7 @@ class DirectusApiManager {
         parseResponse: _api.parseGenericBoolResponse);
   }
 
-  Future<bool> createNewDirectusUser(
+  Future<DirectusCreateUserResult> createNewDirectusUser(
       {required String email,
       required String password,
       String? firstname,

--- a/lib/src/directus_api_manager_base.dart
+++ b/lib/src/directus_api_manager_base.dart
@@ -172,7 +172,7 @@ class DirectusApiManager {
         parseResponse: _api.parseGenericBoolResponse);
   }
 
-  Future<DirectusUser> createNewDirectusUser(
+  Future<bool> createNewDirectusUser(
       {required String email,
       required String password,
       String? firstname,
@@ -187,7 +187,7 @@ class DirectusApiManager {
             lastname: lastname,
             roleUUID: roleUUID,
             otherProperties: otherProperties),
-        parseResponse: (response) => _api.parseUserResponse(response));
+        parseResponse: (response) => _api.parseCreateUserResponse(response));
   }
 
   Future<bool> logoutDirectusUser() async {

--- a/lib/src/model/copyable.dart
+++ b/lib/src/model/copyable.dart
@@ -1,0 +1,3 @@
+abstract class Copyable<T> {
+  T copy();
+}

--- a/lib/src/model/directus_create_user_result.dart
+++ b/lib/src/model/directus_create_user_result.dart
@@ -1,0 +1,8 @@
+import 'package:directus_api_manager/directus_api_manager.dart';
+
+class DirectusCreateUserResult {
+  final bool isSuccess;
+  DirectusUser? userCreated;
+
+  DirectusCreateUserResult({required this.isSuccess, this.userCreated});
+}

--- a/lib/src/model/directus_create_user_result.dart
+++ b/lib/src/model/directus_create_user_result.dart
@@ -1,8 +1,0 @@
-import 'package:directus_api_manager/directus_api_manager.dart';
-
-class DirectusCreateUserResult {
-  final bool isSuccess;
-  DirectusUser? userCreated;
-
-  DirectusCreateUserResult({required this.isSuccess, this.userCreated});
-}

--- a/lib/src/model/directus_item.dart
+++ b/lib/src/model/directus_item.dart
@@ -1,0 +1,5 @@
+import 'package:directus_api_manager/src/model/copyable.dart';
+
+abstract class DirectusItem implements Copyable {
+  fromMap(Map<String, dynamic> data);
+}

--- a/lib/src/model/directus_write_item_result.dart
+++ b/lib/src/model/directus_write_item_result.dart
@@ -1,0 +1,6 @@
+class DirectusWriteItemResult<T> {
+  final bool isSuccess;
+  final T? createdItem;
+
+  const DirectusWriteItemResult({required this.isSuccess, this.createdItem});
+}

--- a/lib/src/model/directus_write_multi_result.dart
+++ b/lib/src/model/directus_write_multi_result.dart
@@ -1,0 +1,7 @@
+class DirectusMultiWriteItemResult<T> {
+  final bool isSuccess;
+  final List<T> createdItemsList;
+
+  const DirectusMultiWriteItemResult(
+      {required this.isSuccess, required this.createdItemsList});
+}

--- a/test/directus_api_test.dart
+++ b/test/directus_api_test.dart
@@ -463,6 +463,24 @@ void main() {
       expect(parsedUser.getValue(forKey: "title"), "CTO");
     });
 
+    test("Parse user creation response 200", () {
+      final sut = DirectusAPI("http://api.com");
+      final parsedUser = sut.parseCreateUserResponse(Response("", 200));
+      expect(parsedUser, true);
+    });
+
+    test("Parse user creation response 204", () {
+      final sut = DirectusAPI("http://api.com");
+      final parsedUser = sut.parseCreateUserResponse(Response("", 204));
+      expect(parsedUser, true);
+    });
+
+    test("Parse user creation response different than 200 and 204", () {
+      final sut = DirectusAPI("http://api.com");
+      final parsedUser = sut.parseCreateUserResponse(Response("", 403));
+      expect(parsedUser, false);
+    });
+
     test('Get list of users request', () {
       final sut = makeAuthenticatedDirectusAPI();
       final request = sut.prepareGetUserListRequest(limit: 10);

--- a/test/directus_api_test.dart
+++ b/test/directus_api_test.dart
@@ -464,21 +464,49 @@ void main() {
     });
 
     test("Parse user creation response 200", () {
+      final responseBody = """
+      {"data":{
+      	"id": "0bc7b36a-9ba9-4ce0-83f0-0a526f354e07",
+        "first_name": "Admin",
+        "last_name": "User",
+        "email": "admin@example.com",
+        "password": "**********",
+        "location": "New York City",
+        "title": "CTO",
+        "description": null,
+        "tags": null,
+        "avatar": null,
+        "language": "en-US",
+        "theme": "auto",
+        "tfa_secret": null,
+        "status": "active",
+        "role": "653925a9-970e-487a-bfc0-ab6c96affcdc",
+        "token": null,
+        "last_access": "2021-02-05T10:18:13-05:00",
+        "last_page": "/settings/roles/653925a9-970e-487a-bfc0-ab6c96affcdc"
+      }}
+      """;
       final sut = DirectusAPI("http://api.com");
-      final parsedUser = sut.parseCreateUserResponse(Response("", 200));
-      expect(parsedUser, true);
+      final createUserResult =
+          sut.parseCreateUserResponse(Response(responseBody, 200));
+      expect(createUserResult.isSuccess, true);
+      expect(createUserResult.userCreated?.id,
+          "0bc7b36a-9ba9-4ce0-83f0-0a526f354e07");
+      expect(createUserResult.userCreated?.email, "admin@example.com");
     });
 
     test("Parse user creation response 204", () {
       final sut = DirectusAPI("http://api.com");
-      final parsedUser = sut.parseCreateUserResponse(Response("", 204));
-      expect(parsedUser, true);
+      final createUserResult = sut.parseCreateUserResponse(Response("", 204));
+      expect(createUserResult.isSuccess, true);
+      expect(createUserResult.userCreated, null);
     });
 
     test("Parse user creation response different than 200 and 204", () {
       final sut = DirectusAPI("http://api.com");
-      final parsedUser = sut.parseCreateUserResponse(Response("", 403));
-      expect(parsedUser, false);
+      final createUserResult = sut.parseCreateUserResponse(Response("", 403));
+      expect(createUserResult.isSuccess, false);
+      expect(createUserResult.userCreated, null);
     });
 
     test('Get list of users request', () {


### PR DESCRIPTION
If we can allow a unlogged user to create an account for our app, we can not allow a unlogged user to get any user in our database for security reason.

So I think it will be better to return a boolean on the account creation. If it is true, then we can logged the user in and provide his account. The app will need to a extra call to the database to get the current user, but it will happened only on user creation.