### PR TITLE
Breaking : Provide object after CRUD calls

### DIFF
--- a/lib/directus_api_manager.dart
+++ b/lib/directus_api_manager.dart
@@ -8,3 +8,4 @@ export 'src/model/directus_file.dart';
 export 'src/model/directus_login_result.dart';
 export 'src/model/directus_item.dart';
 export 'src/model/directus_item_creation_result.dart';
+export 'src/model/directus_api_error.dart';

--- a/lib/directus_api_manager.dart
+++ b/lib/directus_api_manager.dart
@@ -6,3 +6,5 @@ export 'src/sort_property.dart';
 export 'src/model/directus_user.dart';
 export 'src/model/directus_file.dart';
 export 'src/model/directus_login_result.dart';
+export 'src/model/directus_item.dart';
+export 'src/model/directus_item_creation_result.dart';

--- a/lib/src/directus_api.dart
+++ b/lib/src/directus_api.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:developer';
 
 import 'package:directus_api_manager/src/filter.dart';
+import 'package:directus_api_manager/src/model/directus_api_error.dart';
 import 'package:directus_api_manager/src/model/directus_file.dart';
 import 'package:directus_api_manager/src/model/directus_login_result.dart';
 import 'package:directus_api_manager/src/model/directus_user.dart';
@@ -94,18 +95,6 @@ abstract class IDirectusAPI {
       {required String email, String? resetUrl});
   Request preparePasswordChangeRequest(
       {required String token, required String newPassword});
-}
-
-class DirectusApiError {
-  final Response? response;
-  final String? customMessage;
-
-  DirectusApiError({this.response, this.customMessage});
-
-  @override
-  String toString() {
-    return "DirectusApiError : $customMessage : ${response?.statusCode} ${response?.body} ${response?.headers}";
-  }
 }
 
 class DirectusAPI implements IDirectusAPI {

--- a/lib/src/directus_api.dart
+++ b/lib/src/directus_api.dart
@@ -41,7 +41,8 @@ abstract class IDirectusAPI {
       {String fields = "*",
       Filter? filter,
       List<SortProperty>? sortBy,
-      int? limit});
+      int? limit,
+      int? offset});
   Iterable<dynamic> parseGetListOfItemsResponse(Response response);
 
   BaseRequest prepareGetSpecificItemRequest(String itemName, String itemId,
@@ -281,9 +282,14 @@ class DirectusAPI implements IDirectusAPI {
       {String fields = "*",
       Filter? filter,
       List<SortProperty>? sortBy,
-      int? limit}) {
+      int? limit,
+      int? offset}) {
     return _prepareGetRequest("/items/$itemName",
-        filter: filter, fields: fields, sortBy: sortBy, limit: limit);
+        filter: filter,
+        fields: fields,
+        sortBy: sortBy,
+        limit: limit,
+        offset: offset);
   }
 
   @override
@@ -295,7 +301,8 @@ class DirectusAPI implements IDirectusAPI {
       {String fields = "*",
       Filter? filter,
       List<SortProperty>? sortBy,
-      int? limit}) {
+      int? limit,
+      int? offset}) {
     final urlBuilder = StringBuffer(_baseURL + "$path?fields=$fields");
     if (filter != null) {
       urlBuilder.write("&filter=${Uri.encodeQueryComponent(filter.asJSON)}");
@@ -305,6 +312,10 @@ class DirectusAPI implements IDirectusAPI {
     }
     if (sortBy != null && sortBy.isNotEmpty) {
       urlBuilder.write("&sort=" + sortBy.join(","));
+    }
+
+    if (offset != null) {
+      urlBuilder.write("&offset=$offset");
     }
     Request request = Request("GET", Uri.parse(urlBuilder.toString()));
     return authenticateRequest(request);

--- a/lib/src/directus_api_manager_base.dart
+++ b/lib/src/directus_api_manager_base.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:directus_api_manager/directus_api_manager.dart';
 import 'package:directus_api_manager/src/directus_api.dart';
-import 'package:directus_api_manager/src/model/directus_item.dart';
 import 'package:http/http.dart';
 
 class DirectusApiManager {

--- a/lib/src/directus_api_manager_base.dart
+++ b/lib/src/directus_api_manager_base.dart
@@ -301,13 +301,13 @@ class DirectusApiManager {
 
   Future<Type> updateItem<Type extends DirectusItem>(
       {required String typeName,
-      required String objectId,
-      required Map<String, dynamic> objectData,
+      required Type object,
       required Type Function(dynamic json) updateItemFunction,
       String fields = "*"}) {
     return _sendRequest(
         prepareRequest: () => _api.prepareUpdateItemRequest(
-            typeName, objectId, objectData, fields: fields),
+            typeName, object.getValue(forKey: "id"), object.updatedProperties,
+            fields: fields),
         parseResponse: (response) =>
             updateItemFunction(_api.parseUpdateItemResponse(response)));
   }

--- a/lib/src/directus_api_manager_base.dart
+++ b/lib/src/directus_api_manager_base.dart
@@ -223,10 +223,15 @@ class DirectusApiManager {
       List<SortProperty>? sortBy,
       String fields = "*",
       int? limit,
+      int? offset,
       required Type Function(dynamic json) createItemFunction}) {
     return _sendRequest(
         prepareRequest: () => _api.prepareGetListOfItemsRequest(name,
-            filter: filter, sortBy: sortBy, fields: fields, limit: limit),
+            filter: filter,
+            sortBy: sortBy,
+            fields: fields,
+            limit: limit,
+            offset: offset),
         parseResponse: (response) =>
             _api.parseGetListOfItemsResponse(response).map(createItemFunction));
   }

--- a/lib/src/model/directus_api_error.dart
+++ b/lib/src/model/directus_api_error.dart
@@ -1,0 +1,13 @@
+import 'package:http/http.dart';
+
+class DirectusApiError {
+  final Response? response;
+  final String? customMessage;
+
+  DirectusApiError({this.response, this.customMessage});
+
+  @override
+  String toString() {
+    return "DirectusApiError : $customMessage : ${response?.statusCode} ${response?.body} ${response?.headers}";
+  }
+}

--- a/lib/src/model/directus_data.dart
+++ b/lib/src/model/directus_data.dart
@@ -1,0 +1,28 @@
+abstract class DirectusData {
+  final Map<String, dynamic> _rawReceivedData;
+  final Map<String, dynamic> updatedProperties = {};
+
+  DirectusData(this._rawReceivedData) {
+    if (!_rawReceivedData.containsKey("id")) {
+      throw Exception("id is required");
+    }
+  }
+
+  String get id => getValue(forKey: "id");
+  Map<String, dynamic> getRawData() => _rawReceivedData;
+  bool get needsSaving => updatedProperties.isNotEmpty;
+
+  setValue(dynamic value, {required String forKey}) {
+    updatedProperties[forKey] = value;
+  }
+
+  dynamic getValue({required String forKey}) {
+    return updatedProperties[forKey] ?? _rawReceivedData[forKey];
+  }
+
+  Map<String, dynamic> toMap() {
+    return Map<String, dynamic>.of(_rawReceivedData)
+      ..addAll(updatedProperties)
+      ..remove("id");
+  }
+}

--- a/lib/src/model/directus_data.dart
+++ b/lib/src/model/directus_data.dart
@@ -8,7 +8,10 @@ abstract class DirectusData {
     }
   }
 
-  String get id => getValue(forKey: "id");
+  DirectusData.newDirectusData([this._rawReceivedData = const {}]);
+
+  String? get id => getValue(forKey: "id");
+
   Map<String, dynamic> getRawData() => _rawReceivedData;
   bool get needsSaving => updatedProperties.isNotEmpty;
 

--- a/lib/src/model/directus_item.dart
+++ b/lib/src/model/directus_item.dart
@@ -1,4 +1,5 @@
 class DirectusItem {
+  final String id;
   final Map<String, dynamic> _rawReceivedData;
   Map<String, dynamic> getRawData() => _rawReceivedData;
   final Map<String, dynamic> updatedProperties = {};
@@ -13,5 +14,8 @@ class DirectusItem {
   }
 
   /// Creates a new [DirectusItem]
-  DirectusItem(this._rawReceivedData);
+  DirectusItem(this._rawReceivedData)
+      : id = _rawReceivedData.containsKey("id")
+            ? _rawReceivedData["id"]
+            : throw Exception("id is required");
 }

--- a/lib/src/model/directus_item.dart
+++ b/lib/src/model/directus_item.dart
@@ -1,21 +1,8 @@
-class DirectusItem {
-  final String id;
-  final Map<String, dynamic> _rawReceivedData;
-  Map<String, dynamic> getRawData() => _rawReceivedData;
-  final Map<String, dynamic> updatedProperties = {};
-  bool get needsSaving => updatedProperties.isNotEmpty;
+import 'package:directus_api_manager/src/model/directus_data.dart';
 
-  setValue(dynamic value, {required String forKey}) {
-    updatedProperties[forKey] = value;
-  }
+abstract class DirectusItem extends DirectusData {
+  // Creates a new [DirectusItem]
+  DirectusItem(Map<String, dynamic> rawReceivedData) : super(rawReceivedData);
 
-  dynamic getValue({required String forKey}) {
-    return updatedProperties[forKey] ?? _rawReceivedData[forKey];
-  }
-
-  /// Creates a new [DirectusItem]
-  DirectusItem(this._rawReceivedData)
-      : id = _rawReceivedData.containsKey("id")
-            ? _rawReceivedData["id"]
-            : throw Exception("id is required");
+  String get endpointName;
 }

--- a/lib/src/model/directus_item.dart
+++ b/lib/src/model/directus_item.dart
@@ -3,6 +3,7 @@ import 'package:directus_api_manager/src/model/directus_data.dart';
 abstract class DirectusItem extends DirectusData {
   // Creates a new [DirectusItem]
   DirectusItem(Map<String, dynamic> rawReceivedData) : super(rawReceivedData);
+  DirectusItem.newItem() : super.newDirectusData();
+  String get endpointName; // Collection name
 
-  String get endpointName;
 }

--- a/lib/src/model/directus_item_creation_result.dart
+++ b/lib/src/model/directus_item_creation_result.dart
@@ -1,6 +1,9 @@
+import 'package:directus_api_manager/src/model/directus_api_error.dart';
+
 class DirectusItemCreationResult<T> {
   final bool isSuccess;
   List<T> createdItemList = [];
+  DirectusApiError? error;
 
-  DirectusItemCreationResult({required this.isSuccess});
+  DirectusItemCreationResult({required this.isSuccess, this.error});
 }

--- a/lib/src/model/directus_item_creation_result.dart
+++ b/lib/src/model/directus_item_creation_result.dart
@@ -5,5 +5,13 @@ class DirectusItemCreationResult<T> {
   List<T> createdItemList = [];
   DirectusApiError? error;
 
-  DirectusItemCreationResult({required this.isSuccess, this.error});
+  DirectusItemCreationResult({required this.isSuccess, this.error}) {
+    if (!isSuccess && error == null) {
+      throw Exception("error must be initialized");
+    }
+  }
+
+  T? get createdItem {
+    return createdItemList.isEmpty ? null : createdItemList.first;
+  }
 }

--- a/lib/src/model/directus_item_creation_result.dart
+++ b/lib/src/model/directus_item_creation_result.dart
@@ -1,6 +1,6 @@
 class DirectusItemCreationResult<T> {
   final bool isSuccess;
-  final T? createdItem;
+  List<T> createdItemList = [];
 
-  const DirectusItemCreationResult({required this.isSuccess, this.createdItem});
+  DirectusItemCreationResult({required this.isSuccess});
 }

--- a/lib/src/model/directus_user.dart
+++ b/lib/src/model/directus_user.dart
@@ -1,10 +1,6 @@
-class DirectusUser {
-  final String id;
-  final Map<String, dynamic> _rawReceivedData;
-  Map<String, dynamic> getRawData() => _rawReceivedData;
-  final Map<String, dynamic> updatedProperties = {};
-  bool get needsSaving => updatedProperties.isNotEmpty;
+import 'package:directus_api_manager/src/model/directus_data.dart';
 
+class DirectusUser extends DirectusData {
   String get email => getValue(forKey: "email");
   set email(String value) => setValue(value, forKey: "email");
 
@@ -22,14 +18,6 @@ class DirectusUser {
   String? get roleUUID => getValue(forKey: "role");
   set roleUUID(String? value) => setValue(value, forKey: "role");
 
-  setValue(dynamic value, {required String forKey}) {
-    updatedProperties[forKey] = value;
-  }
-
-  dynamic getValue({required String forKey}) {
-    return updatedProperties[forKey] ?? _rawReceivedData[forKey];
-  }
-
   /// Creates a new [DirectusUser]
   ///
   /// [_rawReceivedData] must contain at least an `"id"` and an `"email"` properties. Throws [Exception] if they are missing.
@@ -37,17 +25,11 @@ class DirectusUser {
   /// Can support official properties listed here : https://docs.directus.io/reference/system/users/#the-user-object
   ///
   /// You can add any other custom property that you have added to your *directus_user* model on your server.
-  DirectusUser(this._rawReceivedData)
-      : id = _rawReceivedData.containsKey("id")
-            ? _rawReceivedData["id"]
-            : throw Exception("id is required") {
-    if (_rawReceivedData.containsKey("email") == false) {
+  DirectusUser(Map<String, dynamic> rawReceivedData) : super(rawReceivedData) {
+    if (rawReceivedData.containsKey("email") == false) {
       throw Exception("email is required");
     }
   }
-
-  DirectusUser.from({required this.id, required String email})
-      : _rawReceivedData = {"id": id, "email": email};
 
   String get fullName {
     String result = "";
@@ -64,14 +46,5 @@ class DirectusUser {
     result = result + currentLastName;
 
     return result;
-  }
-
-  Map<String, dynamic> toMap() {
-    return {
-      'id': id,
-      'email': email,
-      'first_name': firstname,
-      'last_name': lastname
-    };
   }
 }

--- a/lib/src/model/directus_user.dart
+++ b/lib/src/model/directus_user.dart
@@ -31,6 +31,8 @@ class DirectusUser extends DirectusData {
     }
   }
 
+  DirectusUser.newDirectusUser() : super.newDirectusData();
+
   String get fullName {
     String result = "";
 

--- a/test/directus_api_test.dart
+++ b/test/directus_api_test.dart
@@ -630,18 +630,22 @@ void main() {
       user.firstname = "Will 2";
       user.setValue(DateTime(2022, 1, 2, 3, 4, 5), forKey: "birthDate");
       final request = sut.prepareUpdateUserRequest(user);
-      expect(request.url.toString(), "http://api.com/users/123-abc-456");
-      expect(request.method, "PATCH");
-      expect(request.headers["Authorization"], "Bearer $defaultAccessToken");
-      final jsonParsedBody = jsonDecode(request.body) as Map;
-      expect(jsonParsedBody["first_name"], "Will 2");
-      expect(jsonParsedBody["birthDate"], "2022-01-02T03:04:05.000");
-      expect(jsonParsedBody.containsKey("email"), false,
-          reason: "Only modified properties should be sent");
-      expect(jsonParsedBody.containsKey("id"), false,
-          reason: "Only modified properties should be sent");
-      expect(jsonParsedBody.containsKey("score"), false,
-          reason: "Only modified properties should be sent");
+      if (request != null) {
+        expect(request.url.toString(), "http://api.com/users/123-abc-456");
+        expect(request.method, "PATCH");
+        expect(request.headers["Authorization"], "Bearer $defaultAccessToken");
+        final jsonParsedBody = jsonDecode(request.body) as Map;
+        expect(jsonParsedBody["first_name"], "Will 2");
+        expect(jsonParsedBody["birthDate"], "2022-01-02T03:04:05.000");
+        expect(jsonParsedBody.containsKey("email"), false,
+            reason: "Only modified properties should be sent");
+        expect(jsonParsedBody.containsKey("id"), false,
+            reason: "Only modified properties should be sent");
+        expect(jsonParsedBody.containsKey("score"), false,
+            reason: "Only modified properties should be sent");
+      } else {
+        expect(request, request is Request, reason: "Request must not be null");
+      }
     });
     test('Update User request with no modification', () {
       final sut = makeAuthenticatedDirectusAPI();
@@ -652,11 +656,15 @@ void main() {
         "score": 23
       });
       final request = sut.prepareUpdateUserRequest(user);
-      expect(request.url.toString(), "http://api.com/users/123-abc-456");
-      expect(request.method, "PATCH");
-      expect(request.headers["Authorization"], "Bearer $defaultAccessToken");
-      final jsonParsedBody = jsonDecode(request.body) as Map;
-      expect(jsonParsedBody, isEmpty);
+      if (request != null) {
+        expect(request.url.toString(), "http://api.com/users/123-abc-456");
+        expect(request.method, "PATCH");
+        expect(request.headers["Authorization"], "Bearer $defaultAccessToken");
+        final jsonParsedBody = jsonDecode(request.body) as Map;
+        expect(jsonParsedBody, isEmpty);
+      } else {
+        expect(request, request is Request, reason: "Request must not be null");
+      }
     });
     test('Request user password reset', () {
       final sut = makeAuthenticatedDirectusAPI();
@@ -706,9 +714,13 @@ void main() {
             "score": 23
           }),
           true);
-      expect(request.url.toString(), "http://api.com/users/123-abc-456");
-      expect(request.method, "DELETE");
-      expect(request.headers["Authorization"], "Bearer $defaultAccessToken");
+      if (request != null) {
+        expect(request.url.toString(), "http://api.com/users/123-abc-456");
+        expect(request.method, "DELETE");
+        expect(request.headers["Authorization"], "Bearer $defaultAccessToken");
+      } else {
+        expect(request, request is Request);
+      }
     });
 
     test('Delete User ok responses', () {

--- a/test/directus_api_test.dart
+++ b/test/directus_api_test.dart
@@ -85,6 +85,15 @@ void main() {
       expect(request.headers["Authorization"], "Bearer $defaultAccessToken");
     });
 
+    test('Get list of items with offset request', () {
+      final sut = makeAuthenticatedDirectusAPI();
+      final request = sut.prepareGetListOfItemsRequest("article", offset: 10);
+      expect(request.url.toString(),
+          'http://api.com/items/article?fields=*&offset=10');
+      expect(request.method, "GET");
+      expect(request.headers["Authorization"], "Bearer $defaultAccessToken");
+    });
+
     test('Get list of items with filter, sort and limit request', () {
       final sut = makeAuthenticatedDirectusAPI();
       final request = sut.prepareGetListOfItemsRequest("article",

--- a/test/model/directus_data_test.dart
+++ b/test/model/directus_data_test.dart
@@ -35,13 +35,12 @@ main() {
     });
 
     test('Generate map of this object', () {
-      final sut = TestDiretusData({"id": "1"});
+      final sut = TestDiretusData({"id": "abc"});
       sut.setValue("coruscant", forKey: "checkString");
       sut.setValue(true, forKey: "checkBool");
       sut.setValue(42, forKey: "checkInt");
       Map<String, dynamic> mapResult = sut.toMap();
 
-      expect(mapResult["id"], "1");
       expect(mapResult["checkString"], "coruscant");
       expect(mapResult["checkBool"], true);
       expect(mapResult["checkInt"], 42);

--- a/test/model/directus_data_test.dart
+++ b/test/model/directus_data_test.dart
@@ -2,31 +2,31 @@ import 'package:directus_api_manager/src/model/directus_data.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 
-class TestDiretusData extends DirectusData {
-  TestDiretusData(Map<String, dynamic> rawReceivedData)
+class TestDirectusData extends DirectusData {
+  TestDirectusData(Map<String, dynamic> rawReceivedData)
       : super(rawReceivedData);
 }
 
 main() {
   group('DirectusData', () {
     test('Creating an invalid item should throw', () {
-      expect(() => TestDiretusData({}), throwsException);
-      expect(() => TestDiretusData({"id": "123-abc"}), returnsNormally);
+      expect(() => TestDirectusData({}), throwsException);
+      expect(() => TestDirectusData({"id": "123-abc"}), returnsNormally);
     });
 
     test('Extra properties can be added and read', () {
-      final sut = TestDiretusData({"id": "abc-123"});
+      final sut = TestDirectusData({"id": "abc-123"});
       sut.setValue("Sète", forKey: "location");
       expect(sut.getValue(forKey: "location"), "Sète");
     });
 
     test('Reading an undefined property returns null without crashing', () {
-      final sut = TestDiretusData({"id": "abc-123"});
+      final sut = TestDirectusData({"id": "abc-123"});
       expect(sut.getValue(forKey: "undefined_property"), null);
     });
 
     test('needsSaving on custom properties', () {
-      final sut = TestDiretusData({
+      final sut = TestDirectusData({
         "id": "abc-123",
       });
       expect(sut.needsSaving, false);
@@ -35,7 +35,7 @@ main() {
     });
 
     test('Generate map of this object', () {
-      final sut = TestDiretusData({"id": "abc"});
+      final sut = TestDirectusData({"id": "abc"});
       sut.setValue("coruscant", forKey: "checkString");
       sut.setValue(true, forKey: "checkBool");
       sut.setValue(42, forKey: "checkInt");

--- a/test/model/directus_data_test.dart
+++ b/test/model/directus_data_test.dart
@@ -1,0 +1,50 @@
+import 'package:directus_api_manager/src/model/directus_data.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+class TestDiretusData extends DirectusData {
+  TestDiretusData(Map<String, dynamic> rawReceivedData)
+      : super(rawReceivedData);
+}
+
+main() {
+  group('DirectusData', () {
+    test('Creating an invalid item should throw', () {
+      expect(() => TestDiretusData({}), throwsException);
+      expect(() => TestDiretusData({"id": "123-abc"}), returnsNormally);
+    });
+
+    test('Extra properties can be added and read', () {
+      final sut = TestDiretusData({"id": "abc-123"});
+      sut.setValue("Sète", forKey: "location");
+      expect(sut.getValue(forKey: "location"), "Sète");
+    });
+
+    test('Reading an undefined property returns null without crashing', () {
+      final sut = TestDiretusData({"id": "abc-123"});
+      expect(sut.getValue(forKey: "undefined_property"), null);
+    });
+
+    test('needsSaving on custom properties', () {
+      final sut = TestDiretusData({
+        "id": "abc-123",
+      });
+      expect(sut.needsSaving, false);
+      sut.setValue("endor", forKey: "location");
+      expect(sut.needsSaving, true);
+    });
+
+    test('Generate map of this object', () {
+      final sut = TestDiretusData({"id": "1"});
+      sut.setValue("coruscant", forKey: "checkString");
+      sut.setValue(true, forKey: "checkBool");
+      sut.setValue(42, forKey: "checkInt");
+      Map<String, dynamic> mapResult = sut.toMap();
+
+      expect(mapResult["id"], "1");
+      expect(mapResult["checkString"], "coruscant");
+      expect(mapResult["checkBool"], true);
+      expect(mapResult["checkInt"], 42);
+    });
+  });
+}

--- a/test/model/directus_item_creation_result_test.dart
+++ b/test/model/directus_item_creation_result_test.dart
@@ -1,0 +1,40 @@
+import 'package:directus_api_manager/directus_api_manager.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+main() {
+  group('DirectusItemCreationResult', () {
+    test('Creating DirectusItemCreationResult', () {
+      expect(
+          () => DirectusItemCreationResult(isSuccess: true), returnsNormally);
+      expect(
+          () => DirectusItemCreationResult(
+              isSuccess: false,
+              error: DirectusApiError(customMessage: "hello world")),
+          returnsNormally);
+      expect(
+          () => DirectusItemCreationResult(isSuccess: false), throwsException);
+    });
+
+    test("CreatedList empty", () {
+      final DirectusItemCreationResult sut =
+          DirectusItemCreationResult(isSuccess: true);
+      expect(sut.createdItem, null);
+    });
+
+    test("CreatedList contains one item", () {
+      final DirectusItemCreationResult sut =
+          DirectusItemCreationResult(isSuccess: true);
+      sut.createdItemList.add("a");
+      expect(sut.createdItem, "a");
+    });
+
+    test("CreatedList contains more than on item", () {
+      final DirectusItemCreationResult sut =
+          DirectusItemCreationResult(isSuccess: true);
+      sut.createdItemList.add("a");
+      sut.createdItemList.add("b");
+      expect(sut.createdItem, "a");
+    });
+  });
+}

--- a/test/model/directus_item_test.dart
+++ b/test/model/directus_item_test.dart
@@ -1,0 +1,32 @@
+import 'package:directus_api_manager/directus_api_manager.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+main() {
+  group('DirectusItem', () {
+    test('Creating an invalid item should throw', () {
+      expect(() => DirectusItem({}), throwsException);
+      expect(() => DirectusItem({"id": "123-abc"}), returnsNormally);
+    });
+
+    test('Extra properties can be added and read', () {
+      final sut = DirectusItem({"id": "abc-123"});
+      sut.setValue("Sète", forKey: "location");
+      expect(sut.getValue(forKey: "location"), "Sète");
+    });
+
+    test('Reading an undefined property returns null without crashing', () {
+      final sut = DirectusItem({"id": "abc-123"});
+      expect(sut.getValue(forKey: "undefined_property"), null);
+    });
+
+    test('needsSaving on custom properties', () {
+      final sut = DirectusItem({
+        "id": "abc-123",
+      });
+      expect(sut.needsSaving, false);
+      sut.setValue("endor", forKey: "location");
+      expect(sut.needsSaving, true);
+    });
+  });
+}

--- a/test/model/directus_item_test.dart
+++ b/test/model/directus_item_test.dart
@@ -5,6 +5,7 @@ import 'package:test/scaffolding.dart';
 class DirectusItemUseCase extends DirectusItem {
   DirectusItemUseCase(Map<String, dynamic> rawReceivedData)
       : super(rawReceivedData);
+  DirectusItemUseCase.newItem() : super.newItem();
 
   @override
   String get endpointName => "itemCollection";
@@ -12,6 +13,10 @@ class DirectusItemUseCase extends DirectusItem {
 
 main() {
   group('DirectusItem', () {
+    test('New Item', () {
+      expect(() => DirectusItemUseCase.newItem(), returnsNormally);
+    });
+
     test('Get the endPoint', () {
       final sut = DirectusItemUseCase({"id": "abc-123"});
       expect(sut.endpointName, "itemCollection");

--- a/test/model/directus_item_test.dart
+++ b/test/model/directus_item_test.dart
@@ -2,31 +2,19 @@ import 'package:directus_api_manager/directus_api_manager.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 
+class DirectusItemUseCase extends DirectusItem {
+  DirectusItemUseCase(Map<String, dynamic> rawReceivedData)
+      : super(rawReceivedData);
+
+  @override
+  String get endpointName => "itemCollection";
+}
+
 main() {
   group('DirectusItem', () {
-    test('Creating an invalid item should throw', () {
-      expect(() => DirectusItem({}), throwsException);
-      expect(() => DirectusItem({"id": "123-abc"}), returnsNormally);
-    });
-
-    test('Extra properties can be added and read', () {
-      final sut = DirectusItem({"id": "abc-123"});
-      sut.setValue("Sète", forKey: "location");
-      expect(sut.getValue(forKey: "location"), "Sète");
-    });
-
-    test('Reading an undefined property returns null without crashing', () {
-      final sut = DirectusItem({"id": "abc-123"});
-      expect(sut.getValue(forKey: "undefined_property"), null);
-    });
-
-    test('needsSaving on custom properties', () {
-      final sut = DirectusItem({
-        "id": "abc-123",
-      });
-      expect(sut.needsSaving, false);
-      sut.setValue("endor", forKey: "location");
-      expect(sut.needsSaving, true);
+    test('Get the endPoint', () {
+      final sut = DirectusItemUseCase({"id": "abc-123"});
+      expect(sut.endpointName, "itemCollection");
     });
   });
 }

--- a/test/model/directus_user_test.dart
+++ b/test/model/directus_user_test.dart
@@ -11,6 +11,11 @@ main() {
       expect(() => DirectusUser({"id": "123-abc", "email": "will@acn.com"}),
           returnsNormally);
     });
+
+    test('New User', () {
+      expect(() => DirectusUser.newDirectusUser(), returnsNormally);
+    });
+
     test('User essential properties are retrieved from property list', () {
       final sut = DirectusUser({
         "id": "abc-123",

--- a/test/model/directus_user_test.dart
+++ b/test/model/directus_user_test.dart
@@ -92,7 +92,6 @@ main() {
       });
       Map<String, dynamic> mapResult = sut.toMap();
 
-      expect(mapResult["id"], "abc-123");
       expect(mapResult["email"], "luke@skywalker.com");
       expect(mapResult["first_name"], "Luke");
       expect(mapResult["last_name"], "Skywalker");


### PR DESCRIPTION
The different CRUD request now return a object or a list of object. The usage of DirectusItemCreationResult is also implemented for the items.

I did also some changes on DirectusItemCreationResult to manage the multi creation call.