### PR TITLE
Avoid unnecessary warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,45 +1,49 @@
+## 1.12.1 - 2025/03/11
+
+-    Avoid error when the cache file is present but empty
+
 ## 1.12.0 - 2025/02/05
 
-- Added new `GeoFilter` class for geospatial filtering
-- Added new `GeoJsonPolygon` class with three constructors for creating geographical areas:
-  - `rectangle`: Creates a rectangular area from top-left and bottom-right coordinates
-  - `polygon`: Creates a custom polygon from a list of coordinates
-  - `squareFromCenter`: Creates a square area from a center point and distance in meters
-- Added `GeoFilterOperator` enum for geospatial operations
-- Moved geospatial filtering functionality from `PropertyFilter` to dedicated `GeoFilter` class
-- Updated documentation with examples for geospatial filtering
+-    Added new `GeoFilter` class for geospatial filtering
+-    Added new `GeoJsonPolygon` class with three constructors for creating geographical areas:
+     -    `rectangle`: Creates a rectangular area from top-left and bottom-right coordinates
+     -    `polygon`: Creates a custom polygon from a list of coordinates
+     -    `squareFromCenter`: Creates a square area from a center point and distance in meters
+-    Added `GeoFilterOperator` enum for geospatial operations
+-    Moved geospatial filtering functionality from `PropertyFilter` to dedicated `GeoFilter` class
+-    Updated documentation with examples for geospatial filtering
 
 ## 1.11.0 - 2025/02/04
 
-- Simplified Websocket subscription creations and stops and added documentation
-- Improved websocket keep alive and disconnects when network is lost
-- Added more functions inside `DirectusApiError` to try to extract valuable information from failed api results
-- Added a MemoryCacheEngine that can be used to store the cache in memory
-- Added new parameters to provide extra caching invalidation : both manual and automatic.
-- Automatically invalidate cached data linked to created, updated or deleted objects
-- Added more cache documentation
+-    Simplified Websocket subscription creations and stops and added documentation
+-    Improved websocket keep alive and disconnects when network is lost
+-    Added more functions inside `DirectusApiError` to try to extract valuable information from failed api results
+-    Added a MemoryCacheEngine that can be used to store the cache in memory
+-    Added new parameters to provide extra caching invalidation : both manual and automatic.
+-    Automatically invalidate cached data linked to created, updated or deleted objects
+-    Added more cache documentation
 
 ## 1.10.0 - 2024/12/31
 
-- Improved locking mechanism to avoid multiple refresh token requests at the same time
-- Added somne locking to json cache file accesses to prevent multiple writes at the same time
-- reduced the amount of read write into the file system for the json cache implementation
-- Changed keys and file naming for the json cache files to avoid issues with the file system with filenames being too long
-- Added the requested url within the cached meta data
-Possible breaking : if apps were using the json cache, the cache files will be renamed and previous cached files will be ignored. On next cache clean, they will be removed.
+-    Improved locking mechanism to avoid multiple refresh token requests at the same time
+-    Added somne locking to json cache file accesses to prevent multiple writes at the same time
+-    reduced the amount of read write into the file system for the json cache implementation
+-    Changed keys and file naming for the json cache files to avoid issues with the file system with filenames being too long
+-    Added the requested url within the cached meta data
+     Possible breaking : if apps were using the json cache, the cache files will be renamed and previous cached files will be ignored. On next cache clean, they will be removed.
 
 ## 1.9.7 - 2024/12/20
 
-- logoutDirectusUser should also clear the cachedCurrentUser variable
+-    logoutDirectusUser should also clear the cachedCurrentUser variable
 
 ## 1.9.6 - 2024/12/20
 
-- logoutDirectusUser now clears all the cache from the specified cache engine
+-    logoutDirectusUser now clears all the cache from the specified cache engine
 
 ## 1.9.5 - 2024/12/18
 
-- Fix : Cache should only save response with status code 200 ... 299
-- Automatically clear list caches when adding or removing items of the same type
+-    Fix : Cache should only save response with status code 200 ... 299
+-    Automatically clear list caches when adding or removing items of the same type
 
 ## 1.9.4 - 2024/12/18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.12.2 - 2025/03/28
+
+-    Reflects previous change to abstract class `IDirectusApiManager`
+
 ## 1.12.1 - 2025/03/11
 
 -    Avoid error when the cache file is present but empty

--- a/lib/src/cache/json_cache_engine.dart
+++ b/lib/src/cache/json_cache_engine.dart
@@ -190,7 +190,7 @@ class JsonCacheEngine implements ILocalDirectusCacheInterface {
       content = null;
     }
     _indexFileLock.release();
-    return content;
+    return content == "" ? null : content;
   }
 
   Future<void> _saveIndexFile(

--- a/lib/src/directus_api_manager_base.dart
+++ b/lib/src/directus_api_manager_base.dart
@@ -800,6 +800,7 @@ class DirectusApiManager implements IDirectusApiManager {
   String? get currentAuthToken => _api.currentAuthToken;
 
   /// Clears the cache for the object with the given [cacheEntryKey].
+  @override
   Future<void> clearCacheWithKey(String cacheEntryKey) async {
     try {
       await cacheEngine?.removeCacheEntry(key: cacheEntryKey);

--- a/lib/src/directus_api_manager_base.dart
+++ b/lib/src/directus_api_manager_base.dart
@@ -282,6 +282,7 @@ class DirectusApiManager implements IDirectusApiManager {
   }
 
   /// Discards the cached current user information.
+  @override
   void discardCurrentUserCache() {
     cachedCurrentUser = null;
     clearCacheWithKey(_currentUserRequestIdentifier);

--- a/lib/src/idirectus_api_manager.dart
+++ b/lib/src/idirectus_api_manager.dart
@@ -12,7 +12,12 @@ abstract class IDirectusApiManager {
       String? firstname,
       String? lastname});
   Future<bool> hasLoggedInUser();
-  Future<DirectusUser?> currentDirectusUser({String fields = "*"});
+  Future<DirectusUser?> currentDirectusUser(
+      {String fields = "*",
+      bool canUseCacheForResponse = false,
+      bool canSaveResponseToCache = true,
+      bool canUseOldCachedResponseAsFallback = true,
+      Duration maxCacheAge = const Duration(days: 1)});
 
   Future<bool> requestPasswordReset({required String email, String? resetUrl});
   Future<bool> confirmPasswordReset(
@@ -23,9 +28,26 @@ abstract class IDirectusApiManager {
       List<SortProperty>? sortBy,
       String? fields,
       int? limit,
-      int? offset});
+      int? offset,
+      String? requestIdentifier,
+      bool canUseCacheForResponse = false,
+      bool canSaveResponseToCache = true,
+      bool canUseOldCachedResponseAsFallback = true,
+
+      /// Extra tags to associate with the cache entry
+      List<String> extraTags = const [],
+      Duration maxCacheAge = const Duration(days: 1)});
   Future<Type?> getSpecificItem<Type extends DirectusData>(
-      {required String id, String? fields});
+      {required String id,
+      String? fields,
+      String? requestIdentifier,
+      bool canUseCacheForResponse = false,
+      bool canSaveResponseToCache = true,
+      bool canUseOldCachedResponseAsFallback = true,
+
+      /// Extra tags to associate with the cache entry
+      List<String> extraTags = const [],
+      Duration maxCacheAge = const Duration(days: 1)});
 
   Future<DirectusItemCreationResult<Type>>
       createNewItem<Type extends DirectusData>({
@@ -51,7 +73,8 @@ abstract class IDirectusApiManager {
       String? title,
       String? contentType,
       String? folder,
-      String storage});
+      String storage = "local",
+      Map<String, dynamic>? additionalFields});
   Future<DirectusFile> updateExistingFile(
       {required List<int> fileBytes,
       required String fileId,
@@ -67,4 +90,6 @@ abstract class IDirectusApiManager {
   Future<bool> tryAndRefreshToken();
   String get webSocketBaseUrl;
   String get baseUrl;
+  Future<void> clearCacheWithKey(String cacheEntryKey);
+  void discardCurrentUserCache();
 }

--- a/lib/test/mock_directus_api_manager.dart
+++ b/lib/test/mock_directus_api_manager.dart
@@ -40,9 +40,19 @@ class MockDirectusApiManager extends IDirectusApiManager with MockMixin {
   }
 
   @override
-  Future<DirectusUser?> currentDirectusUser({String fields = "*"}) {
+  Future<DirectusUser?> currentDirectusUser(
+      {String fields = "*",
+      bool canUseCacheForResponse = false,
+      bool canSaveResponseToCache = true,
+      bool canUseOldCachedResponseAsFallback = true,
+      Duration maxCacheAge = const Duration(days: 1)}) {
     addCalledFunction(named: "currentDirectusUser");
     addReceivedObject(fields, name: "fields");
+    addReceivedObject(canUseCacheForResponse, name: "canUseCacheForResponse");
+    addReceivedObject(canSaveResponseToCache, name: "canSaveResponseToCache");
+    addReceivedObject(canUseOldCachedResponseAsFallback,
+        name: "canUseOldCachedResponseAsFallback");
+    addReceivedObject(maxCacheAge, name: "maxCacheAge");
     return Future.value(popNextReturnedObject());
   }
 
@@ -77,22 +87,49 @@ class MockDirectusApiManager extends IDirectusApiManager with MockMixin {
       List<SortProperty>? sortBy,
       String? fields,
       int? limit,
-      int? offset}) {
+      int? offset,
+      String? requestIdentifier,
+      bool canUseCacheForResponse = false,
+      bool canSaveResponseToCache = true,
+      bool canUseOldCachedResponseAsFallback = true,
+      List<String> extraTags = const [],
+      Duration maxCacheAge = const Duration(days: 1)}) {
     addCalledFunction(named: "findListOfItems");
     addReceivedObject(filter, name: "filter");
     addReceivedObject(sortBy, name: "sortBy");
     addReceivedObject(fields, name: "fields");
     addReceivedObject(limit, name: "limit");
     addReceivedObject(offset, name: "offset");
+    addReceivedObject(requestIdentifier, name: "requestIdentifier");
+    addReceivedObject(canUseCacheForResponse, name: "canUseCacheForResponse");
+    addReceivedObject(canSaveResponseToCache, name: "canSaveResponseToCache");
+    addReceivedObject(canUseOldCachedResponseAsFallback,
+        name: "canUseOldCachedResponseAsFallback");
+    addReceivedObject(extraTags, name: "extraTags");
+    addReceivedObject(maxCacheAge, name: "maxCacheAge");
     return Future.value(popNextReturnedObject());
   }
 
   @override
   Future<Type?> getSpecificItem<Type extends DirectusData>(
-      {required String id, String? fields}) {
+      {required String id,
+      String? fields,
+      String? requestIdentifier,
+      bool canUseCacheForResponse = false,
+      bool canSaveResponseToCache = true,
+      bool canUseOldCachedResponseAsFallback = true,
+      List<String> extraTags = const [],
+      Duration maxCacheAge = const Duration(days: 1)}) {
     addCalledFunction(named: "getSpecificItem");
     addReceivedObject(id, name: "id");
     addReceivedObject(fields, name: "fields");
+    addReceivedObject(requestIdentifier, name: "requestIdentifier");
+    addReceivedObject(canUseCacheForResponse, name: "canUseCacheForResponse");
+    addReceivedObject(canSaveResponseToCache, name: "canSaveResponseToCache");
+    addReceivedObject(canUseOldCachedResponseAsFallback,
+        name: "canUseOldCachedResponseAsFallback");
+    addReceivedObject(extraTags, name: "extraTags");
+    addReceivedObject(maxCacheAge, name: "maxCacheAge");
     return Future.value(popNextReturnedObject());
   }
 
@@ -169,13 +206,15 @@ class MockDirectusApiManager extends IDirectusApiManager with MockMixin {
       String? title,
       String? contentType,
       String? folder,
-      String storage = "local"}) {
+      String storage = "local",
+      Map<String, dynamic>? additionalFields}) {
     addCalledFunction(named: "uploadFile");
     addReceivedObject(fileBytes, name: "fileBytes");
     addReceivedObject(filename, name: "filename");
     addReceivedObject(title, name: "title");
     addReceivedObject(contentType, name: "contentType");
     addReceivedObject(folder, name: "folder");
+    addReceivedObject(additionalFields, name: "additionalFields");
     return Future.value(popNextReturnedObject());
   }
 
@@ -222,5 +261,18 @@ class MockDirectusApiManager extends IDirectusApiManager with MockMixin {
       "lastname": lastname
     });
     return Future.value(popNextReturnedObject());
+  }
+
+  @override
+  Future<void> clearCacheWithKey(String cacheEntryKey) {
+    addCall(
+        named: "clearCacheWithKey",
+        arguments: {"cacheEntryKey": cacheEntryKey});
+    return Future.value();
+  }
+
+  @override
+  void discardCurrentUserCache() {
+    addCall(named: "discardCurrentUserCache");
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: directus_api_manager
 description: Communicate with a Directus server using its REST API.
-version: 1.12.1
+version: 1.12.2
 repository: https://github.com/maxbritto/directus_api_manager
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: directus_api_manager
 description: Communicate with a Directus server using its REST API.
-version: 1.12.0
+version: 1.12.1
 repository: https://github.com/maxbritto/directus_api_manager
 
 environment:

--- a/test/model/directus_data_test.dart
+++ b/test/model/directus_data_test.dart
@@ -5,8 +5,7 @@ import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
 
 class TestDirectusData extends DirectusData {
-  TestDirectusData(Map<String, dynamic> rawReceivedData)
-      : super(rawReceivedData);
+  TestDirectusData(super.rawReceivedData);
 }
 
 main() {


### PR DESCRIPTION
Remove warning when the cache index file exists but is empty.
Reflect some missing changes made to IDirectusApiManager