### PR TITLE
Expose accessToken setter

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,10 @@
+targets:
+     $default:
+          builders:
+               reflectable_builder:
+                    generate_for:
+                         - example/**.dart
+                         - test/**.dart
+                         - lib/**.dart
+                    options:
+                         formatted: true

--- a/lib/src/directus_api.dart
+++ b/lib/src/directus_api.dart
@@ -70,6 +70,7 @@ abstract class IDirectusAPI {
 
   PreparedRequest prepareLoginRequest(String username, String password,
       {String? oneTimePassword});
+  PreparedRequest prepareLoginRequestWithProvider({required String provider});
   DirectusLoginResult parseLoginResponse(Response response);
 
   PreparedRequest prepareUserInviteRequest(String email, String roleId);
@@ -631,6 +632,13 @@ class DirectusAPI implements IDirectusAPI {
       if (lastname != null) "last_name": lastname
     });
     request.addJsonHeaders();
+    return PreparedRequest(request: request);
+  }
+
+  @override
+  PreparedRequest prepareLoginRequestWithProvider({required String provider}) {
+    final request = Request("GET", Uri.parse("$_baseURL/auth/login/$provider"));
+
     return PreparedRequest(request: request);
   }
 }

--- a/lib/src/directus_api.dart
+++ b/lib/src/directus_api.dart
@@ -8,7 +8,9 @@ abstract class IDirectusAPI {
   bool get hasLoggedInUser;
   bool get shouldRefreshToken;
   String? get accessToken;
+  set accessToken(String? value);
   String? get currentAuthToken;
+
   String? get refreshToken;
   set refreshToken(String? value);
   String get baseUrl;
@@ -70,7 +72,7 @@ abstract class IDirectusAPI {
 
   PreparedRequest prepareLoginRequest(String username, String password,
       {String? oneTimePassword});
-  PreparedRequest prepareLoginRequestWithProvider({required String provider});
+
   DirectusLoginResult parseLoginResponse(Response response);
 
   PreparedRequest prepareUserInviteRequest(String email, String roleId);
@@ -115,6 +117,8 @@ class DirectusAPI implements IDirectusAPI {
   String get baseUrl => _baseURL;
 
   String? _accessToken;
+  @override
+  set accessToken(String? value) => _accessToken = value;
   String? _refreshToken;
   @override
   set refreshToken(String? value) => _refreshToken = value;
@@ -632,13 +636,6 @@ class DirectusAPI implements IDirectusAPI {
       if (lastname != null) "last_name": lastname
     });
     request.addJsonHeaders();
-    return PreparedRequest(request: request);
-  }
-
-  @override
-  PreparedRequest prepareLoginRequestWithProvider({required String provider}) {
-    final request = Request("GET", Uri.parse("$_baseURL/auth/login/$provider"));
-
     return PreparedRequest(request: request);
   }
 }

--- a/lib/src/directus_api.dart
+++ b/lib/src/directus_api.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:directus_api_manager/directus_api_manager.dart';
 import 'package:http/http.dart';
+import 'package:http_parser/http_parser.dart';
 
 abstract class IDirectusAPI {
   bool get hasLoggedInUser;

--- a/lib/src/directus_api_manager_base.dart
+++ b/lib/src/directus_api_manager_base.dart
@@ -259,21 +259,18 @@ class DirectusApiManager implements IDirectusApiManager {
     _currentUserLock = completer.future;
 
     try {
-      if (cachedCurrentUser == null && await hasLoggedInUser()) {
-        cachedCurrentUser = await _sendRequest(
-            requestIdentifier: _currentUserRequestIdentifier,
-            canSaveResponseToCache: canSaveResponseToCache,
-            canUseCacheForResponse: canUseCacheForResponse,
-            canUseOldCachedResponseAsFallback:
-                canUseOldCachedResponseAsFallback,
-            maxCacheAge: maxCacheAge,
-            prepareRequest: () =>
-                _api.prepareGetCurrentUserRequest(fields: fields),
-            parseResponse: (response) {
-              final parsedJson = _api.parseGetSpecificItemResponse(response);
-              return DirectusUser(parsedJson);
-            });
-      }
+      cachedCurrentUser ??= await _sendRequest(
+          requestIdentifier: _currentUserRequestIdentifier,
+          canSaveResponseToCache: canSaveResponseToCache,
+          canUseCacheForResponse: canUseCacheForResponse,
+          canUseOldCachedResponseAsFallback: canUseOldCachedResponseAsFallback,
+          maxCacheAge: maxCacheAge,
+          prepareRequest: () =>
+              _api.prepareGetCurrentUserRequest(fields: fields),
+          parseResponse: (response) {
+            final parsedJson = _api.parseGetSpecificItemResponse(response);
+            return DirectusUser(parsedJson);
+          });
     } catch (error) {
       print(error);
     }

--- a/lib/src/directus_api_manager_base.dart
+++ b/lib/src/directus_api_manager_base.dart
@@ -61,6 +61,8 @@ class DirectusApiManager implements IDirectusApiManager {
   bool get shouldRefreshToken => _api.shouldRefreshToken;
   @override
   String? get accessToken => _api.accessToken;
+  @override
+  set accessToken(String? value) => _api.accessToken = value;
 
   @override
   String? get refreshToken => _api.refreshToken;
@@ -891,16 +893,5 @@ class DirectusApiManager implements IDirectusApiManager {
       stopWebsocketSubscription(webSocketSubscriptionId);
       startWebsocketSubscription(existingSubscription);
     }
-  }
-
-  @override
-  Future<DirectusLoginResult> loginDirectusUserWithProvider(
-      {required String provider}) {
-    return _sendRequest(
-        prepareRequest: () =>
-            _api.prepareLoginRequestWithProvider(provider: provider),
-        dependsOnToken: false,
-        canSaveResponseToCache: false,
-        parseResponse: (response) => _api.parseLoginResponse(response));
   }
 }

--- a/lib/src/directus_api_manager_base.dart
+++ b/lib/src/directus_api_manager_base.dart
@@ -892,4 +892,15 @@ class DirectusApiManager implements IDirectusApiManager {
       startWebsocketSubscription(existingSubscription);
     }
   }
+
+  @override
+  Future<DirectusLoginResult> loginDirectusUserWithProvider(
+      {required String provider}) {
+    return _sendRequest(
+        prepareRequest: () =>
+            _api.prepareLoginRequestWithProvider(provider: provider),
+        dependsOnToken: false,
+        canSaveResponseToCache: false,
+        parseResponse: (response) => _api.parseLoginResponse(response));
+  }
 }

--- a/lib/src/directus_api_manager_base.dart
+++ b/lib/src/directus_api_manager_base.dart
@@ -259,18 +259,21 @@ class DirectusApiManager implements IDirectusApiManager {
     _currentUserLock = completer.future;
 
     try {
-      cachedCurrentUser ??= await _sendRequest(
-          requestIdentifier: _currentUserRequestIdentifier,
-          canSaveResponseToCache: canSaveResponseToCache,
-          canUseCacheForResponse: canUseCacheForResponse,
-          canUseOldCachedResponseAsFallback: canUseOldCachedResponseAsFallback,
-          maxCacheAge: maxCacheAge,
-          prepareRequest: () =>
-              _api.prepareGetCurrentUserRequest(fields: fields),
-          parseResponse: (response) {
-            final parsedJson = _api.parseGetSpecificItemResponse(response);
-            return DirectusUser(parsedJson);
-          });
+      if (cachedCurrentUser == null && await hasLoggedInUser()) {
+        cachedCurrentUser = await _sendRequest(
+            requestIdentifier: _currentUserRequestIdentifier,
+            canSaveResponseToCache: canSaveResponseToCache,
+            canUseCacheForResponse: canUseCacheForResponse,
+            canUseOldCachedResponseAsFallback:
+                canUseOldCachedResponseAsFallback,
+            maxCacheAge: maxCacheAge,
+            prepareRequest: () =>
+                _api.prepareGetCurrentUserRequest(fields: fields),
+            parseResponse: (response) {
+              final parsedJson = _api.parseGetSpecificItemResponse(response);
+              return DirectusUser(parsedJson);
+            });
+      }
     } catch (error) {
       print(error);
     }

--- a/lib/src/idirectus_api_manager.dart
+++ b/lib/src/idirectus_api_manager.dart
@@ -5,6 +5,8 @@ abstract class IDirectusApiManager {
   Future<DirectusLoginResult> loginDirectusUser(
       String username, String password,
       {String? oneTimePassword});
+  Future<DirectusLoginResult> loginDirectusUserWithProvider(
+      {required String provider});
   Future<bool> logoutDirectusUser();
   Future<bool> registerDirectusUser(
       {required String email,

--- a/lib/src/idirectus_api_manager.dart
+++ b/lib/src/idirectus_api_manager.dart
@@ -5,8 +5,6 @@ abstract class IDirectusApiManager {
   Future<DirectusLoginResult> loginDirectusUser(
       String username, String password,
       {String? oneTimePassword});
-  Future<DirectusLoginResult> loginDirectusUserWithProvider(
-      {required String provider});
   Future<bool> logoutDirectusUser();
   Future<bool> registerDirectusUser(
       {required String email,
@@ -88,6 +86,7 @@ abstract class IDirectusApiManager {
       required T Function(Response) jsonConverter});
   bool get shouldRefreshToken;
   String? get accessToken;
+  set accessToken(String? value);
   String? get refreshToken;
   Future<bool> tryAndRefreshToken();
   String get webSocketBaseUrl;

--- a/lib/test/mock_directus_api_manager.dart
+++ b/lib/test/mock_directus_api_manager.dart
@@ -284,4 +284,9 @@ class MockDirectusApiManager extends IDirectusApiManager with MockMixin {
         arguments: {"provider": provider});
     return Future.value(popNextReturnedObject());
   }
+
+  @override
+  set accessToken(String? value) {
+    addCall(named: "set accessToken", arguments: {"value": value});
+  }
 }

--- a/lib/test/mock_directus_api_manager.dart
+++ b/lib/test/mock_directus_api_manager.dart
@@ -275,4 +275,13 @@ class MockDirectusApiManager extends IDirectusApiManager with MockMixin {
   void discardCurrentUserCache() {
     addCall(named: "discardCurrentUserCache");
   }
+
+  @override
+  Future<DirectusLoginResult> loginDirectusUserWithProvider(
+      {required String provider}) {
+    addCall(
+        named: "loginDirectusUserWithProvider",
+        arguments: {"provider": provider});
+    return Future.value(popNextReturnedObject());
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: directus_api_manager
 description: Communicate with a Directus server using its REST API.
-version: 1.14.2
+version: 1.14.3
 repository: https://github.com/maxbritto/directus_api_manager
 
 environment:
@@ -9,22 +9,14 @@ environment:
 dependencies:
      http: ">=0.13.4 <2.0.0"
      http_parser: ^4.0.2
-     reflectable: ">=4.0.1 <6.0.0" 
+     reflectable: ">=4.0.1 <6.0.0"
      web_socket_channel: ^3.0.3
      extension_dart_tools: ^1.4.1
      meta: "^1.15.0"
      mutex: ^3.1.0
 
 dev_dependencies:
+     reflectable_builder: any
      build_runner: any
      lints: ^6.0.0
-     test: ^1.27.0
-
-targets:
-     $default:
-          builders:
-               reflectable:
-                    generate_for:
-                         - example/directus_api_manager_example.dart
-                    options:
-                         formatted: true
+     test: ^1.26.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
      http: ">=0.13.4 <2.0.0"
+     http_parser: ">=4.0.0 <5.0.0"
      reflectable: ^5.1.0
      web_socket_channel: ^3.0.3
      extension_dart_tools: ^1.4.1

--- a/test/directus_api_manager_base_test.dart
+++ b/test/directus_api_manager_base_test.dart
@@ -28,6 +28,12 @@ void main() {
       );
     });
 
+    test("Set access token", () {
+      sut.accessToken = "NEW.ACCESS.TOKEN";
+      expect(mockDirectusApi.calledFunctions, contains("set accessToken"));
+      expect(mockDirectusApi.receivedObjects["value"], "NEW.ACCESS.TOKEN");
+    });
+
     test('Empty manager does not have a logged in user', () async {
       final mockClient = MockHTTPClient();
       final sut =

--- a/test/directus_api_test.dart
+++ b/test/directus_api_test.dart
@@ -32,6 +32,15 @@ void main() {
     });
   });
 
+  group("DirectusAPI Setter", () {
+    test("Set access token", () {
+      final sut = DirectusAPI("http://api.com");
+      expect(sut.accessToken, isNull);
+      sut.accessToken = "NEW.ACCESS.TOKEN";
+      expect(sut.accessToken, "NEW.ACCESS.TOKEN");
+    });
+  });
+
   group("DirectusAPI Data Management", () {
     test('Get list of items request', () {
       final sut = makeAuthenticatedDirectusAPI();

--- a/test/mock/mock_directus_api.dart
+++ b/test/mock/mock_directus_api.dart
@@ -333,9 +333,8 @@ class MockDirectusApi with MockMixin implements IDirectusAPI {
   }
 
   @override
-  PreparedRequest prepareLoginRequestWithProvider({required String provider}) {
-    addCalledFunction(named: "prepareLoginRequestWithProvider");
-    addReceivedObject(provider, name: "provider");
-    return nextReturnedRequest;
+  set accessToken(String? value) {
+    addCalledFunction(named: "set accessToken");
+    addReceivedObject(value, name: "value");
   }
 }

--- a/test/mock/mock_directus_api.dart
+++ b/test/mock/mock_directus_api.dart
@@ -331,4 +331,11 @@ class MockDirectusApi with MockMixin implements IDirectusAPI {
     addReceivedObject(lastname, name: "lastname");
     return nextReturnedRequest;
   }
+
+  @override
+  PreparedRequest prepareLoginRequestWithProvider({required String provider}) {
+    addCalledFunction(named: "prepareLoginRequestWithProvider");
+    addReceivedObject(provider, name: "provider");
+    return nextReturnedRequest;
+  }
 }


### PR DESCRIPTION
This release expose accessToken setter. It's useful when the user use a provider in the login process.

I had to downgrade test dependancies in order to run the tests. I still don't understand why.